### PR TITLE
Add Jest test for mobile menu toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Scomed-Website
 Scomed Medical Equipment and Supplies business website
 visit the website at https://lecahill.github.io/Scomed-Website/
+
+## Testing
+
+This project uses Jest with JSDOM for unit testing.
+
+Run the tests with:
+
+```
+npm install
+npm test
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 
                 <nav>
 
-                    <img class="mobile-exit" id="mobiile-menu-exit" src="images/icons/exit.svg" alt="menu exit icon">
+                    <img class="mobile-exit" id="mobile-menu-exit" src="images/icons/exit.svg" alt="menu exit icon">
 
                     <ul class="primary-nav">
                         <li><a href="#">Products</a></li>
@@ -325,7 +325,7 @@
 
         // Mobile menu open
         const mobileMenuBtn = document.getElementById('mobile-menu');
-        const mobileMenuExit = document.getElementById('mobiile-menu-exit');
+        const mobileMenuExit = document.getElementById('mobile-menu-exit');
         const nav = document.querySelector('.navbar nav');
 
         mobileMenuBtn.addEventListener('click', () => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "scomed-website",
+  "version": "1.0.0",
+  "description": "Scomed Medical Equipment and Supplies business website visit the website at https://lecahill.github.io/Scomed-Website/",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/mobileMenu.test.js
+++ b/tests/mobileMenu.test.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('mobile menu interactions', () => {
+  let dom;
+
+  beforeAll(async () => {
+    const htmlPath = path.join(__dirname, '..', 'docs', 'index.html');
+    dom = await JSDOM.fromFile(htmlPath, {
+      runScripts: 'dangerously',
+      resources: 'usable'
+    });
+    await new Promise(resolve => {
+      dom.window.document.addEventListener('DOMContentLoaded', resolve);
+    });
+  });
+
+  afterAll(() => {
+    dom.window.close();
+  });
+
+  test('opens and closes the mobile navigation menu', () => {
+    const { document } = dom.window;
+    const mobileMenuBtn = document.getElementById('mobile-menu');
+    const mobileMenuExit = document.getElementById('mobile-menu-exit');
+    const nav = document.querySelector('.navbar nav');
+
+    // Open the menu
+    mobileMenuBtn.click();
+    expect(nav.classList.contains('open')).toBe(true);
+    expect(mobileMenuBtn.style.display).toBe('none');
+    expect(mobileMenuExit.style.display).toBe('block');
+
+    // Close the menu
+    mobileMenuExit.click();
+    expect(nav.classList.contains('open')).toBe(false);
+    expect(mobileMenuBtn.style.display).toBe('block');
+    expect(mobileMenuExit.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest/Jsdom config and npm test script
- fix mobile menu exit button id
- test mobile menu toggles `open` class and button visibility

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bb8549b18832f93c3e5ef759782af