### PR TITLE
Use responsive height for hero image

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -103,7 +103,7 @@ body {
 }
 .hero .hero-image {
   width: 100%;
-  height: 340px;
+  height: clamp(120px, 40vh, 340px);
   -o-object-fit: cover;
      object-fit: cover;
   display: block;
@@ -114,7 +114,7 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  height: 340px;
+  height: clamp(120px, 40vh, 340px);
   background: rgba(34, 34, 34, 0.45);
   border-radius: 12px;
   z-index: 1;
@@ -626,7 +626,6 @@ body {
     width: 100%;
   }
   .hero .hero-image, .hero .hero-overlay {
-    height: 180px;
     border-radius: 0;
   }
   .hero .hero-text h1 {
@@ -666,9 +665,6 @@ body {
   }
 }
 @media (max-width: 480px) {
-  .hero .hero-image, .hero .hero-overlay {
-    height: 120px;
-  }
   .container {
     padding: 0 0.5rem;
   }

--- a/css/main.scss
+++ b/css/main.scss
@@ -115,7 +115,7 @@ body {
   }
   .hero-image {
     width: 100%;
-    height: 340px;
+    height: clamp(120px, 40vh, 340px);
     object-fit: cover;
     display: block;
     border-radius: $border-radius;
@@ -123,7 +123,7 @@ body {
   .hero-overlay {
     position: absolute;
     top: 0; left: 0;
-    width: 100%; height: 340px;
+    width: 100%; height: clamp(120px, 40vh, 340px);
     background: rgba(34,34,34,0.45);
     border-radius: $border-radius;
     z-index: 1;
@@ -649,7 +649,6 @@ body {
   }
   .hero {
     .hero-image, .hero-overlay {
-      height: 180px;
       border-radius: 0;
     }
     .hero-text {
@@ -693,9 +692,6 @@ body {
 }
 
 @media (max-width: 480px) {
-  .hero .hero-image, .hero .hero-overlay {
-    height: 120px;
-  }
   .container {
     padding: 0 0.5rem;
   }


### PR DESCRIPTION
## Summary
- make hero image and overlay heights fluid with `clamp`
- remove redundant hero height media query overrides

## Testing
- `npx sass css/main.scss css/main.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bb89aee54832fbf53a33f93da18db